### PR TITLE
Create directory for .ignore files

### DIFF
--- a/git/.gitignore-nim
+++ b/git/.gitignore-nim
@@ -1,0 +1,27 @@
+# .gitignore-nim
+# A .gitignore suitable for use with a Nim project
+
+# Cached files
+nimcache/
+nimblecache/
+
+# Docs
+htmldocs/
+
+# Object & Shared-object files
+*.so
+*.o
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# C libraries
+*.lib
+*.a
+*.la
+*.lo

--- a/git/.gitignore-terraform
+++ b/git/.gitignore-terraform
@@ -1,0 +1,9 @@
+# .gitignore-terraform
+# Add this to a project using Terraform scripts
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*

--- a/ignore/.fdignore
+++ b/ignore/.fdignore
@@ -1,0 +1,102 @@
+#  .fdignore
+#
+# Files matching these patterns will not be searched by default when using `fd`
+# To override these settings use the appropriate flag below:
+#    --no-ignore        : don't respect .ignore, .gitignore, .fdignore
+#    --no-ignore-vcs    : don't respect .gitignore files
+
+# Python byte-compiled/optimized/DLL files
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*$py.class
+
+# Object & Shared-object files
+*.so
+*.o
+*.ko
+*.obj
+*.elf
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# C libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Python distribution/packaging
+.Python
+develop-eggs/
+.eggs/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+site-packages/
+distutils/
+
+# Unit test / coverage reports
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Sphinx documentation
+docs/_build/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+.python-version
+
+# mypy
+.mypy_cache/
+
+# Java
+*.class
+hs_err_pid*
+.gradle
+.gradle*cache
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Perl
+*.pm.tdy
+.precomp
+lib/.precomp
+
+# Nim
+nimcache/
+nimblecache/
+
+# Jekyll
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata

--- a/ignore/.gitignore
+++ b/ignore/.gitignore
@@ -1,6 +1,7 @@
 # .gitignore
 # This .gitignore is probably not the best for your specific project, since it ignores a lot of patterns
 # Check the top-level git directory for language specific .gitignore files.
+# https://github.com/eindiran/dotfiles/tree/master/git
 
 *.a
 *.app

--- a/ignore/.gitignore
+++ b/ignore/.gitignore
@@ -1,3 +1,7 @@
+# .gitignore
+# This .gitignore is probably not the best for your specific project, since it ignores a lot of patterns
+# Check the top-level git directory for language specific .gitignore files.
+
 *.a
 *.app
 *.aux
@@ -48,7 +52,6 @@ hs_err_pid*
 *.idb
 *.ilk
 .installed.cfg
-*.jar
 .jekyll-cache/
 .jekyll-metadata
 *.ko

--- a/ignore/.rgignore
+++ b/ignore/.rgignore
@@ -1,0 +1,113 @@
+#  .rgignore
+#
+# Files matching these patterns will not be searched by default when using `rg`
+# To override these settings, the appropriate flag below:
+#    --no-ignore        : don't respect .ignore, .gitignore, .rgignore
+#    --no-ignore-dot    : don't respect .ignore files
+#    --no-ignore-vcs    : don't respect .gitignore files
+#    --no-ignore-global : don't respect globally sourced ignore dotfiles
+#    --no-ignore-parent : don't respect ignore dotfiles from parent directories
+
+# Python byte-compiled/optimized/DLL files
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*$py.class
+
+# Object & Shared-object files
+*.so
+*.o
+*.ko
+*.obj
+*.elf
+
+# Executables
+*.exe
+*.app
+*.i*86
+*.x86_64
+
+# C libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Python distribution/packaging
+.Python
+develop-eggs/
+.eggs/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Unit test / coverage reports
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Django
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+.python-version
+Pipfile.lock
+
+# mypy
+.mypy_cache/
+.dmypy.json
+
+# Java
+*.class
+hs_err_pid*
+.gradle
+.gradle*cache
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Perl
+*.pm.tdy
+.precomp
+lib/.precomp
+
+# Nim
+nimcache/
+nimblecache/
+
+# Jekyll
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+
+# Packaged files
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar


### PR DESCRIPTION
This new directory is intended to hold ignore files, e.g. `.gitignore`, `.rgignore`, `.fdignore`
Files that will be added in the initial run:
- `.fdignore`: For the `find`-like file searching utility `fd`
- `.rgignore`: For `rg`
- `.gitignore`