### PR TITLE
Add script for installing Vundle plugins

### DIFF
--- a/install_dotfiles.sh
+++ b/install_dotfiles.sh
@@ -130,5 +130,8 @@ cp tmux/scripts/* ~/.tmux/scripts
 
 # Copy over .vimrc
 cp vim/.vimrc ~/.vimrc
+./vim/install_plugins.sh
+## Overwrite the default comments.templates file from bash-support:
+cp vim/shell-template/comments.templates ~/.vim/bundle/bash-support.vim/bash-support/templates/comments.templates
 
 echo "Installation of dotfiles complete!"

--- a/vim/install_plugins.sh
+++ b/vim/install_plugins.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#===============================================================================
+#
+#          FILE: install_plugins.sh
+#
+#         USAGE: ./install_plugins.sh [/path/to/.vimrc]
+#
+#   DESCRIPTION: Use the PluginInstall command from Vundle to install all Vundle
+#                plugins listed in the current .vimrc
+#
+#       OPTIONS: May optionally specify the .vimrc file to use.
+#  REQUIREMENTS: vim
+#        AUTHOR: Elliott Indiran <elliott.indiran@protonmail.com>
+#===============================================================================
+
+set -Eeuo pipefail
+
+if [ "$#" -eq 0 ]; then
+    # When no args are passed, use the user's standard .vimrc, usually $HOME/.vimrc
+    vim +PluginInstall +qall
+elif [ "$#" -eq 1 ]; then
+    # If a path is specified, ues that .vimrc file instead
+    vim +PluginInstall +qall -u "$1"
+else
+    # If more than 1 arg is passed, print out the usage:
+    printf "Incorrect number of arguments passed!\nUsage:\t"
+    printf "./install_plugins.sh [/path/to/.vimrc]\n"
+    exit 1
+fi

--- a/vim/shell-template/comments.templates
+++ b/vim/shell-template/comments.templates
@@ -1,0 +1,92 @@
+§ =============================================================
+§  Comments
+§ =============================================================
+
+== Comments.end-of-line comment == nomenu, append ==
+# <CURSOR>
+== Comments.frame == map:cfr, sc:r ==
+#-------------------------------------------------------------------------------
+# <CURSOR>
+#-------------------------------------------------------------------------------
+== Comments.function == map:cfu, sc:f ==
+#---  FUNCTION  ----------------------------------------------------------------
+#          NAME:  |?FUNCTION_NAME|
+#   DESCRIPTION:  <CURSOR>
+#    PARAMETERS:
+#       RETURNS:
+#-------------------------------------------------------------------------------
+== Comments.file header == start, map:ch ==
+#!/usr/bin/env bash
+#===============================================================================
+#
+#          FILE: |FILENAME|
+#
+#         USAGE: ./|FILENAME|
+#
+#   DESCRIPTION:
+#
+#       OPTIONS: ---
+#  REQUIREMENTS: ---
+#         NOTES: ---
+#        AUTHOR: |AUTHOR| (|AUTHORREF|), |EMAIL|
+#  ORGANIZATION: |ORGANIZATION|
+#       CREATED: |DATE| |TIME|
+#      REVISION:  ---
+#===============================================================================
+
+set -Eeuo pipefail
+<CURSOR>
+== ENDTEMPLATE ==
+
+§ -------------------------------------------------------------
+
+== Comments.date == insert, map:cd, sc:d ==
+|DATE|<CURSOR>
+== Comments.date+time == insert, map:ct, sc:t ==
+|DATE| |TIME|<CURSOR>
+== ENDTEMPLATE ==
+
+§ -------------------------------------------------------------
+§  Keywords, Special and Macros
+§ -------------------------------------------------------------
+
+== LIST: comments_sections == hash ==
+	'GLOBAL DECLARATIONS'     : 'GLOBAL DECLARATIONS',
+	'COMMAND LINE PROCESSING' : 'COMMAND LINE PROCESSING',
+	'SANITY CHECKS'           : 'SANITY CHECKS',
+	'FUNCTION DEFINITIONS'    : 'FUNCTION DEFINITIONS',
+	'TRAPS'                   : 'TRAPS',
+	'MAIN SCRIPT'             : 'MAIN SCRIPT',
+	'STATISTICS AND CLEAN-UP' : 'STATISTICS AND CLEAN-UP',
+== LIST: comments_keywords == hash ==
+	'bug'         : ':BUG:|DATE| |TIME|:|AUTHORREF|: <CURSOR>',
+	'todo'        : ':TODO:|DATE| |TIME|:|AUTHORREF|: <CURSOR>',
+	'tricky'      : ':TRICKY:|DATE| |TIME|:|AUTHORREF|: <CURSOR>',
+	'warning'     : ':WARNING:|DATE| |TIME|:|AUTHORREF|: <CURSOR>',
+	'workaround'  : ':WORKAROUND:|DATE| |TIME|:|AUTHORREF|: <CURSOR>',
+	'new keyword' : ':<CURSOR>:|DATE| |TIME|:|AUTHORREF|: {+COMMENT+}',
+== LIST: comments_macros == hash ==
+	'AUTHOR'       : '|AUTHOR|',
+	'AUTHORREF'    : '|AUTHORREF|',
+	'COMPANY'      : '|COMPANY|',
+	'COPYRIGHT'    : '|COPYRIGHT|',
+	'EMAIL'        : '|EMAIL|',
+	'ORGANIZATION' : '|ORGANIZATION|',
+== ENDLIST ==
+
+§ -------------------------------------------------------------
+
+== Comments.script sections == expandmenu, map:css, sc:s ==
+|PickList( 'script sections', 'comments_sections' )|
+#===============================================================================
+#  |PICK|
+#===============================================================================
+== Comments.keyword comments == expandmenu, append, map:ckc, sc:k ==
+|PickList( 'keyword comment', 'comments_keywords' )|
+ # |PICK|
+== Comments.macros == expandmenu, insert, map:cma, sc:m ==
+|PickList( 'macro', 'comments_macros' )|
+|PICK|
+== ENDTEMPLATE ==
+
+== SEP: Comments.sep1 ==


### PR DESCRIPTION
* Adds a new script, `install_plugins.sh` which installs Vundle plugins from a `.vimrc` file.
* Adds my modified copy of the `comments.templates` file for bash-support vim plugin.
* Use both changes in `install_dotfiles.sh`.